### PR TITLE
Remove decimal precision from time and file size displays

### DIFF
--- a/.claude/TODO.md
+++ b/.claude/TODO.md
@@ -12,10 +12,6 @@ When all elements in a section are complete, simply replace the list of tasks wi
 
 **S1**: Eliminate "Mode" settings for visualizer, hardcode to constant Q. Eliminate Weighting, hardcode to A-weighting. Eliminate speed, hardcode to medium. The only option should be palette.
 
-**S2.1**: The time slider should not show decimal precision. It's too much. Just show seconds.
-
-**S2.2**: The file size doesn't need decimal precision either. Just show KB.
-
 ---
 
 ## ENHANCEMENT (new features & styling)

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,6 @@
         "@typescript-eslint/parser": "5.59.9",
         "auto-bind": "^5.0.1",
         "autoprefixer": "7.1.6",
-        "bytes": "latest",
         "chalk": "^2.4.1",
         "chroma-js": "^1.4.0",
         "directory-tree": "2.2.1",
@@ -637,8 +636,6 @@
     "buffer-indexof-polyfill": ["buffer-indexof-polyfill@1.0.2", "", {}, "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="],
 
     "buffers": ["buffers@0.1.1", "", {}, "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="],
-
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@typescript-eslint/parser": "5.59.9",
     "auto-bind": "^5.0.1",
     "autoprefixer": "7.1.6",
-    "bytes": "latest",
     "chalk": "^2.4.1",
     "chroma-js": "^1.4.0",
     "directory-tree": "2.2.1",

--- a/src/__tests__/formatting.test.ts
+++ b/src/__tests__/formatting.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { formatFileSize } from '../util';
+
+describe('formatFileSize', () => {
+  it('should format zero bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+  });
+
+  it('should format bytes under 1 KB', () => {
+    expect(formatFileSize(500)).toBe('500 B');
+    expect(formatFileSize(1023)).toBe('1023 B');
+  });
+
+  it('should format exactly 1 KB', () => {
+    expect(formatFileSize(1024)).toBe('1 KB');
+  });
+
+  it('should round KB values without decimals', () => {
+    expect(formatFileSize(7100)).toBe('7 KB');    // 6.93 KB rounded
+    expect(formatFileSize(16511)).toBe('16 KB');  // 16.12 KB rounded
+    expect(formatFileSize(21000)).toBe('21 KB');  // 20.51 KB rounded
+  });
+
+  it('should handle large KB values', () => {
+    expect(formatFileSize(165707)).toBe('162 KB'); // 161.82 KB rounded
+    expect(formatFileSize(471433)).toBe('460 KB'); // 460.38 KB rounded
+  });
+
+  it('should format MB values', () => {
+    expect(formatFileSize(1048576)).toBe('1 MB');   // Exactly 1 MB
+    expect(formatFileSize(1572864)).toBe('2 MB');   // 1.5 MB rounded up
+    expect(formatFileSize(2621440)).toBe('3 MB');   // 2.5 MB rounded up
+  });
+});

--- a/src/components/Browse.tsx
+++ b/src/components/Browse.tsx
@@ -2,9 +2,9 @@ import React, { Fragment } from 'react';
 import autoBindReact from 'auto-bind/react';
 import VirtualizedList from './VirtualizedList';
 import DirectoryLink from './DirectoryLink';
-import bytes from 'bytes';
 import trimEnd from 'lodash/trimEnd';
 import { BrowseProps } from '../types/app';
+import { formatFileSize } from '../util';
 
 
 export default class Browse extends React.PureComponent<BrowseProps> {
@@ -73,7 +73,7 @@ export default class Browse extends React.PureComponent<BrowseProps> {
               {item.mtime}
             </div>
             <div className="BrowseList-colSize" title={`Directory size is ${item.size} bytes (recursive)`}>
-              {item.size != null && bytes(item.size, { unitSeparator: ' ' })}
+              {item.size != null && formatFileSize(item.size)}
             </div>
           </>
         );
@@ -91,7 +91,7 @@ export default class Browse extends React.PureComponent<BrowseProps> {
               {item.mtime}
             </div>
             <div className="BrowseList-colSize">
-              {bytes(item.size, { unitSeparator: ' ' })}
+              {formatFileSize(item.size)}
             </div>
           </>
         );

--- a/src/components/TimeSlider.tsx
+++ b/src/components/TimeSlider.tsx
@@ -68,8 +68,8 @@ export default class TimeSlider extends React.Component<TimeSliderProps, TimeSli
     const sign = ms < 0 ? '-' : '';
     ms = Math.abs(ms);
     const min = Math.floor(ms / 60000);
-    const sec = (Math.floor((ms % 60000) / 100) / 10).toFixed(1);
-    return `${sign}${min}:${pad(parseFloat(sec))}`;
+    const sec = Math.floor((ms % 60000) / 1000);
+    return `${sign}${min}:${pad(sec)}`;
   }
 
   handlePositionDrag(event: React.ChangeEvent<HTMLInputElement> | number): void {

--- a/src/util.ts
+++ b/src/util.ts
@@ -216,3 +216,14 @@ export function formatSongDisplayName(songUrl: string | null): string {
 
   return `${folder} - ${filenameWithoutExt}`;
 }
+
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+
+  const mb = kb / 1024;
+  return `${Math.round(mb)} MB`;
+}


### PR DESCRIPTION
## Summary

Implements S2.1 and S2.2 from the TODO list:
- Time slider displays integer seconds (e.g., "1:30" instead of "1:30.5")
- File sizes display rounded KB values (e.g., "7 KB" instead of "6.93 KB")
- Small files (< 1 KB) still display in bytes (e.g., "500 B")

## Changes

- Modified `TimeSlider.tsx` to use `Math.floor()` for integer seconds
- Added `formatFileSize()` utility function to `util.ts`
- Updated `Browse.tsx` to use new formatter
- Removed `bytes` npm dependency (reduces bundle size)
- Added comprehensive unit tests for file size formatting

## Testing

- All 9 unit tests pass ✓
- Comprehensive test coverage for `formatFileSize()` function
- Edge cases handled: zero bytes, bytes, KB, MB, rounding

🤖 Generated with [Claude Code](https://claude.com/claude-code)